### PR TITLE
Update for nektos/act compatibility

### DIFF
--- a/.github/workflows/arduino-compile-sketches.yml
+++ b/.github/workflows/arduino-compile-sketches.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: '17'
           java-package: 'jre'
       - run: | 
-          if [ ! -f /usr/bin/java ] ; then ln -s $JAVA_HOME/bin/java /usr/bin/java ; fi
+          if [ ! -f /usr/bin/java ] ; then ln -s `which java` /usr/bin/java ; fi
       - uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.fqbn }}


### PR DESCRIPTION
There are some slight differences between the nektos/act docker environment and GitHubs runners. This update should work in either, and also should have a better chance of working if the environments change in the future. 